### PR TITLE
fix documentation typo

### DIFF
--- a/doc/flog.txt
+++ b/doc/flog.txt
@@ -74,7 +74,7 @@ gb                                              *flog-gb*
 
 Toggle the "--bisect" argument.
 
-gb                                              *flog-gm*
+gm                                              *flog-gm*
 
 Toggle the "--no-merges" argument.
 


### PR DESCRIPTION
The docs showed both `flog-gb` and `flog-gm` as mapped to `gb`.