### PR TITLE
flog#parse_log_output: skip "..." lines (e.g. with "-G")

### DIFF
--- a/autoload/flog.vim
+++ b/autoload/flog.vim
@@ -438,6 +438,10 @@ function! flog#parse_log_output(output) abort
 
   let l:commits = []
   for l:raw_commit in l:raw_commits
+    if l:raw_commit ==# "...\n"
+      " Skip "..." lines when using e.g. "-G" with "--graph".
+      continue
+    endif
     let l:commits += [flog#parse_log_commit(l:raw_commit)]
   endfor
   return l:commits


### PR DESCRIPTION
When using `-raw-args=-G\ 'foo\ bar'` to filter log entries, lines only
containing "..." might be added (due to usage of `--graph`).

Skip parsing those lines as commits.  They will still be displayed in
the resulting buffer then (linked to the previous commit, e.g. for
`<CR>`).