### PR TITLE
Fix branches refs with path separator not parsed correctly

### DIFF
--- a/autoload/flog.vim
+++ b/autoload/flog.vim
@@ -1397,7 +1397,7 @@ function! flog#get_cache_curr_line_refs(cache) abort
 
       if l:ref =~# 'HEAD$\|^refs/'
         call add(l:special, l:ref)
-      elseif l:ref =~# '/'
+      elseif l:ref =~# '[' . join(flog#get_remotes(), '\|') . ']/'
         call add(l:remote_branches, l:ref)
       elseif l:original_refs[l:i] =~# '^tag: '
         call add(l:tags, l:ref)


### PR DESCRIPTION
Now the branch refs with a path separator are parsed correctly, **if** the ref does not include any remote name in it

Closes #31 