### PR TITLE
Added ability to navigate parent/child commits

### DIFF
--- a/autoload/flog.vim
+++ b/autoload/flog.vim
@@ -1102,9 +1102,18 @@ function! flog#find_predicate(haystack, predicate) abort
   return get(filter(copy(a:haystack), "a:predicate(v:val)"), 0, v:null)
 endfunction
 
+fu! flog#find_commit(state, commit_hash) abort
+  return flog#find_predicate(a:state.commits, {item -> flog#starts_with(a:commit_hash, item.short_commit_hash)})
+endfunction
+
 fu! flog#jump_to_commit(commit_hash) abort
   let l:state = flog#get_state()
-  let l:commit = flog#find_predicate(l:state.commits, {item -> flog#starts_with(a:commit_hash, item.short_commit_hash)})
+  let l:commit = flog#find_commit(l:state, a:commit_hash)
+  if type(l:commit) != v:t_dict
+    let l:state.reflog = v:true
+    call flog#populate_graph_buffer()
+    let l:commit = flog#find_commit(l:state, a:commit_hash)
+  endif
   let l:index = index(l:state.commits, l:commit)
   let l:index = min([max([l:index, 0]), len(l:state.commits) - 1])
   let l:line = index(l:state.line_commits, l:state.commits[l:index]) + 1

--- a/autoload/flog.vim
+++ b/autoload/flog.vim
@@ -967,6 +967,35 @@ function! flog#previous_commit() abort
   call flog#jump_commits(-v:count1)
 endfunction
 
+" if the star symbol ever changes, this will remain
+" the backwards compatible way of going to the last
+" char that is a part of the graph drawing
+fu! flog#to_commit_start() abort
+  execute "normal! 0f*"
+endfunction
+
+" If you bind these to j and k,
+" you can more naturally go up and down one commit,
+" while still being able to use your relative
+" line numbers as expected
+function! flog#up() abort
+  if v:count1 == 1
+    call flog#previous_commit()
+  else
+    execute "normal! " . v:count1 . "k"
+  endif
+  call flog#to_commit_start()
+endfunction
+
+function! flog#down() abort
+  if v:count1 == 1
+    call flog#next_commit()
+  else
+    execute "normal! " . v:count1 . "j"
+  endif
+  call flog#to_commit_start()
+endfunction
+
 " }}}
 
 function! flog#copy_commits(...) range abort
@@ -1050,7 +1079,7 @@ endfunction
 
 " See https://vi.stackexchange.com/questions/29056/how-to-find-first-item-that-satisfies-predicate/29059#29059
 function! flog#find_predicate(haystack, predicate) abort
-    return get(filter(copy(a:haystack), "a:predicate(v:val)"), 0, v:null)
+  return get(filter(copy(a:haystack), "a:predicate(v:val)"), 0, v:null)
 endfunction
 
 fu! flog#jump_to_commit(commit_hash) abort
@@ -1061,8 +1090,7 @@ fu! flog#jump_to_commit(commit_hash) abort
   let l:line = index(l:state.line_commits, l:state.commits[l:index]) + 1
   if l:line >= 0
     exec l:line
-    " to end up on the star symbol of the commit:
-    exec "normal! 0f*"
+    call flog#to_commit_start()
   endif
 endfunction
 

--- a/autoload/flog.vim
+++ b/autoload/flog.vim
@@ -1063,13 +1063,6 @@ endfunction
 
 " Quick navigate operations {{{
 
-" if the star symbol ever changes, this will remain
-" the backwards compatible way of going to the last
-" char that is a part of the graph drawing
-fu! flog#to_commit_start() abort
-  execute 'normal! 0f*'
-endfunction
-
 " If you bind these to j and k,
 " you can more naturally go up and down one commit,
 " while still being able to use your relative
@@ -1080,7 +1073,6 @@ function! flog#up() abort
   else
     execute 'normal! ' . v:count1 . 'k'
   endif
-  call flog#to_commit_start()
 endfunction
 
 function! flog#down() abort
@@ -1089,7 +1081,6 @@ function! flog#down() abort
   else
     execute 'normal! ' . v:count1 . 'j'
   endif
-  call flog#to_commit_start()
 endfunction
 
 " See https://vi.stackexchange.com/questions/29062/how-to-check-if-a-string-starts-with-another-string-in-vimscript/29063#29063
@@ -1119,7 +1110,6 @@ fu! flog#jump_to_commit(commit_hash) abort
   let l:line = index(l:state.line_commits, l:state.commits[l:index]) + 1
   if l:line >= 0
     exec l:line
-    call flog#to_commit_start()
   endif
 endfunction
 

--- a/autoload/flog.vim
+++ b/autoload/flog.vim
@@ -1067,7 +1067,7 @@ endfunction
 " the backwards compatible way of going to the last
 " char that is a part of the graph drawing
 fu! flog#to_commit_start() abort
-  execute "normal! 0f*"
+  execute 'normal! 0f*'
 endfunction
 
 " If you bind these to j and k,
@@ -1078,7 +1078,7 @@ function! flog#up() abort
   if v:count1 == 1
     call flog#previous_commit()
   else
-    execute "normal! " . v:count1 . "k"
+    execute 'normal! ' . v:count1 . 'k'
   endif
   call flog#to_commit_start()
 endfunction
@@ -1087,7 +1087,7 @@ function! flog#down() abort
   if v:count1 == 1
     call flog#next_commit()
   else
-    execute "normal! " . v:count1 . "j"
+    execute 'normal! ' . v:count1 . 'j'
   endif
   call flog#to_commit_start()
 endfunction
@@ -1099,7 +1099,7 @@ endfunction
 
 " See https://vi.stackexchange.com/questions/29056/how-to-find-first-item-that-satisfies-predicate/29059#29059
 function! flog#find_predicate(haystack, predicate) abort
-  return get(filter(copy(a:haystack), "a:predicate(v:val)"), 0, v:null)
+  return get(filter(copy(a:haystack), 'a:predicate(v:val)'), 0, v:null)
 endfunction
 
 fu! flog#find_commit(state, commit_hash) abort
@@ -1174,7 +1174,7 @@ fu! flog#jump_up_N_parents(amount) abort
   endif
   let c = 0
   while c < a:amount
-    let l:parent_commit = system("git rev-list --parents -n 1 " . l:current_commit)
+    let l:parent_commit = system('git rev-list --parents -n 1 ' . l:current_commit)
     let l:parents = split(l:parent_commit)[1:]
     if len(l:parents) == 0
       return
@@ -1212,7 +1212,7 @@ fu! flog#jump_to_child() abort
 endfunction
 
 fu! flog#offset_head_hash() abort
-  return fugitive#RevParse("HEAD@{" . g:flog_head_offset . "}")
+  return fugitive#RevParse('HEAD@{' . g:flog_head_offset . '}')
 endfunction
 
 fu! flog#jump_to_offset_head(offset) abort
@@ -1229,7 +1229,7 @@ fu! flog#jump_to_offset_head(offset) abort
   endif
   let l:head_commit = flog#offset_head_hash()
   call flog#jump_to_commit(l:head_commit)
-  echom "HEAD@{" . g:flog_head_offset . "}"
+  echom 'HEAD@{' . g:flog_head_offset . '}'
 endfunction
 
 " For example, bind to [h

--- a/autoload/flog.vim
+++ b/autoload/flog.vim
@@ -1123,13 +1123,8 @@ fu! flog#get_short_commit_hash() abort
   return l:current_commit.short_commit_hash
 endfunction
 
-fu! flog#rev_parse(revitem) abort
-  let rev_parse = system("git rev-parse " . a:revitem)
-  return split(rev_parse)[0]
-endfunction
-
 fu! flog#get_full_commit_hash() abort
-  return flog#rev_parse(flog#get_short_commit_hash())
+  return fugitive#RevParse(flog#get_short_commit_hash())
 endfunction
 
 " Returns one of the elements of the list.
@@ -1198,7 +1193,7 @@ fu! flog#jump_to_child() abort
 endfunction
 
 fu! flog#offset_head_hash() abort
-  return flog#rev_parse("HEAD@{" . g:flog_head_offset . "}")
+  return fugitive#RevParse("HEAD@{" . g:flog_head_offset . "}")
 endfunction
 
 fu! flog#jump_to_offset_head(offset) abort

--- a/autoload/flog.vim
+++ b/autoload/flog.vim
@@ -1124,6 +1124,10 @@ fu! flog#get_short_commit_hash() abort
 endfunction
 
 fu! flog#get_full_commit_hash() abort
+  let l:short = flog#get_short_commit_hash()
+  if type(l:short) != v:t_string
+    return v:null
+  endif
   return fugitive#RevParse(flog#get_short_commit_hash())
 endfunction
 
@@ -1156,6 +1160,9 @@ endfunction
 
 fu! flog#jump_up_N_parents(amount) abort
   let l:current_commit = flog#get_full_commit_hash()
+  if type(l:current_commit) != v:t_string
+    return v:null
+  endif
   let c = 0
   while c < a:amount
     let l:parent_commit = system("git rev-list --parents -n 1 " . l:current_commit)
@@ -1175,6 +1182,9 @@ endfunction
 
 fu! flog#jump_down_N_children(amount) abort
   let l:current_commit = flog#get_full_commit_hash()
+  if type(l:current_commit) != v:t_string
+    return v:null
+  endif
   let c = 0
   while c < a:amount
     let l:child_commit = system("git log --format='%H %P' --all --reflog | grep -F \" " . l:current_commit . "\" | cut -f1 -d' '")
@@ -1198,6 +1208,9 @@ endfunction
 
 fu! flog#jump_to_offset_head(offset) abort
   let l:current_commit = flog#get_full_commit_hash()
+  if type(l:current_commit) != v:t_string
+    return v:null
+  endif
   let l:current_head_commit = flog#offset_head_hash()
   if g:flog_head_offset == 0 || l:current_commit == l:current_head_commit
     let g:flog_head_offset = max([0, g:flog_head_offset + a:offset])

--- a/autoload/flog.vim
+++ b/autoload/flog.vim
@@ -1191,7 +1191,7 @@ fu! flog#jump_down_N_children(amount) abort
   endif
   let c = 0
   let l:git_log_command = flog#get_fugitive_git_command() . " log --format='%H %P' --all --reflog"
-  let l:parent_log = split(system(l:git_log_command), '\n')
+  let l:parent_log = systemlist(l:git_log_command)
   while c < a:amount
     let l:children = flog#find_all_predicate(l:parent_log, {log_line -> match(log_line, ' ' . l:current_commit) != -1})
     if len(l:children) == 0
@@ -1218,8 +1218,7 @@ fu! flog#jump_to_offset_head(offset) abort
   endif
   let l:current_head_commit = flog#offset_head_hash()
   if g:flog_head_offset == 0 || l:current_commit == l:current_head_commit
-    let l:reflog = system(flog#get_fugitive_git_command() . ' reflog')
-    let l:reflog_lines = split(l:reflog, '\n')
+    let l:reflog_lines = systemlist(flog#get_fugitive_git_command() . ' reflog')
     let l:reflog_size = len(l:reflog_lines)
     let g:flog_head_offset = min([max([0, g:flog_head_offset + a:offset]), l:reflog_size - 1])
   else

--- a/autoload/flog.vim
+++ b/autoload/flog.vim
@@ -967,35 +967,6 @@ function! flog#previous_commit() abort
   call flog#jump_commits(-v:count1)
 endfunction
 
-" if the star symbol ever changes, this will remain
-" the backwards compatible way of going to the last
-" char that is a part of the graph drawing
-fu! flog#to_commit_start() abort
-  execute "normal! 0f*"
-endfunction
-
-" If you bind these to j and k,
-" you can more naturally go up and down one commit,
-" while still being able to use your relative
-" line numbers as expected
-function! flog#up() abort
-  if v:count1 == 1
-    call flog#previous_commit()
-  else
-    execute "normal! " . v:count1 . "k"
-  endif
-  call flog#to_commit_start()
-endfunction
-
-function! flog#down() abort
-  if v:count1 == 1
-    call flog#next_commit()
-  else
-    execute "normal! " . v:count1 . "j"
-  endif
-  call flog#to_commit_start()
-endfunction
-
 " }}}
 
 function! flog#copy_commits(...) range abort
@@ -1070,6 +1041,55 @@ function! flog#jump_refs(refs) abort
   if l:line >= 0
     exec l:line
   endif
+endfunction
+
+function! flog#jump_to_ref(ref) abort
+  let l:state = flog#get_state()
+  if !has_key(l:state.ref_line_lookup, a:ref)
+    return
+  endif
+  exec l:state.ref_line_lookup[a:ref] + 1
+endfunction
+
+function! flog#next_ref() abort
+  call flog#jump_refs(v:count1)
+endfunction
+
+function! flog#previous_ref() abort
+  call flog#jump_refs(-v:count1)
+endfunction
+
+" }}}
+
+" Quick navigate operations {{{
+
+" if the star symbol ever changes, this will remain
+" the backwards compatible way of going to the last
+" char that is a part of the graph drawing
+fu! flog#to_commit_start() abort
+  execute "normal! 0f*"
+endfunction
+
+" If you bind these to j and k,
+" you can more naturally go up and down one commit,
+" while still being able to use your relative
+" line numbers as expected
+function! flog#up() abort
+  if v:count1 == 1
+    call flog#previous_commit()
+  else
+    execute "normal! " . v:count1 . "k"
+  endif
+  call flog#to_commit_start()
+endfunction
+
+function! flog#down() abort
+  if v:count1 == 1
+    call flog#next_commit()
+  else
+    execute "normal! " . v:count1 . "j"
+  endif
+  call flog#to_commit_start()
 endfunction
 
 " See https://vi.stackexchange.com/questions/29062/how-to-check-if-a-string-starts-with-another-string-in-vimscript/29063#29063
@@ -1172,23 +1192,6 @@ endfunction
 fu! flog#jump_to_child() abort
   call flog#jump_down_N_children(v:count1)
 endfunction
-
-function! flog#jump_to_ref(ref) abort
-  let l:state = flog#get_state()
-  if !has_key(l:state.ref_line_lookup, a:ref)
-    return
-  endif
-  exec l:state.ref_line_lookup[a:ref] + 1
-endfunction
-
-function! flog#next_ref() abort
-  call flog#jump_refs(v:count1)
-endfunction
-
-function! flog#previous_ref() abort
-  call flog#jump_refs(-v:count1)
-endfunction
-
 
 " }}}
 

--- a/autoload/flog.vim
+++ b/autoload/flog.vim
@@ -1222,7 +1222,8 @@ fu! flog#jump_to_offset_head(offset) abort
   endif
   let l:current_head_commit = flog#offset_head_hash()
   if g:flog_head_offset == 0 || l:current_commit == l:current_head_commit
-    let g:flog_head_offset = max([0, g:flog_head_offset + a:offset])
+    let l:reflog_size = str2nr(substitute(system('git reflog | wc -l'), '\v\C\n$', '', '')) - 1
+    let g:flog_head_offset = min([max([0, g:flog_head_offset + a:offset]), l:reflog_size])
   else
     let g:flog_head_offset = 0
   endif

--- a/plugin/flog.vim
+++ b/plugin/flog.vim
@@ -10,6 +10,7 @@ let g:loaded_flog = 1
 
 " Global state {{{
 
+let g:flog_head_offset = 0
 let g:flog_instance_counter = 0
 let g:flog_visited_commits = []
 

--- a/plugin/flog.vim
+++ b/plugin/flog.vim
@@ -12,7 +12,6 @@ let g:loaded_flog = 1
 
 let g:flog_head_offset = 0
 let g:flog_instance_counter = 0
-let g:flog_visited_commits = []
 
 " }}}
 

--- a/plugin/flog.vim
+++ b/plugin/flog.vim
@@ -8,6 +8,19 @@ let g:loaded_flog = 1
 
 " }}}
 
+" Default mappings {{{
+
+if !exists("g:flog_no_default_mappings")
+  augroup flog
+    autocmd FileType floggraph nno <buffer> <silent> h :<C-U>call flog#jump_to_parent()<CR>
+    autocmd FileType floggraph nno <buffer> <silent> j :<C-U>call flog#down()<CR>
+    autocmd FileType floggraph nno <buffer> <silent> k :<C-U>call flog#up()<CR>
+    autocmd FileType floggraph nno <buffer> <silent> l :<C-U>call flog#jump_to_child()<CR>
+  augroup END
+endif
+
+" }}}
+
 " Global state {{{
 
 let g:flog_head_offset = 0

--- a/plugin/flog.vim
+++ b/plugin/flog.vim
@@ -11,6 +11,7 @@ let g:loaded_flog = 1
 " Global state {{{
 
 let g:flog_instance_counter = 0
+let g:flog_visited_commits = []
 
 " }}}
 


### PR DESCRIPTION
Added functions to autoload/flog.vim to navigate to children and parents. This is the same as GitExtensions' Cntrl-P and Cntrl-N shortcuts. To bind, do something like:

```
augroup flog
  autocmd FileType floggraph nno <buffer> <silent> ]c :<C-U>call flog#jump_to_parent()<CR>
  autocmd FileType floggraph nno <buffer> <silent> [c :<C-U>call flog#jump_to_child()<CR>
augroup END
```

It does this in a stable way by recording the previous inputs and outputs, so that going up X times and then down X times, or vice-verse, you always end up on the same commit*. So you navigate down through parents from your feature branch back onto develop (before you had started your branch), navigating back up to children will go back to your feature branch. It is also stable in that it always ends up on the * symbol of the commit graph, so that you could use this in a macro to e.g. get the commit messages of a branch into a buffer.

Navigating to child commits also works if they are only available in the reflog, ~assuming that vim-flog is set to display such commits (use `gr` in the graph to toggle this).~ and will enable the reflog if necessary while navigating.

* Unless you hit the top or bottom of the git graph, of course; then such navigation is a no-op.