### PR TITLE
Set nomodeline for flog graph buffers

### DIFF
--- a/ftplugin/floggraph.vim
+++ b/ftplugin/floggraph.vim
@@ -6,6 +6,7 @@ silent setlocal nomodifiable
       \ buftype=nofile
       \ bufhidden=wipe
       \ cursorline
+      \ nomodeline
 
 " Mappings {{{
 


### PR DESCRIPTION
This fixes issue #61; while rare, a commit message
that exactly conforms to a modeline setting would
enable it to set settings which ideally would not pose
a security problem, but (neo)vim will probably always
have some unpatched exploits.

See also: https://security.stackexchange.com/questions/36001/vim-modeline-vulnerabilities

There is no valid use-case for a modeline in a non-editable
buffer such as the flog git log graph.