### PR TITLE
Add b:flog_status_summary for use in e.g. vim-airline

### DIFF
--- a/autoload/flog.vim
+++ b/autoload/flog.vim
@@ -1239,6 +1239,7 @@ endfunction
 
 function! flog#populate_graph_buffer() abort
   let l:state = flog#get_state()
+  let b:flog_status_summary = flog#get_status_summary()
 
   let l:cursor = flog#get_graph_cursor()
 
@@ -1379,6 +1380,21 @@ function! flog#clear_graph_update_hook() abort
   augroup FlogGraphUpdate
     autocmd! * <buffer>
   augroup END
+endfunction
+
+function! flog#get_status_summary() abort
+  let l:command = flog#get_fugitive_git_command()
+  let l:changes = len(systemlist(l:command . ' status -s'))
+  if l:changes == 0
+    let l:change_summary = 'no changes'
+  else 
+    let l:change_summary = l:changes . ' changed file'
+  endif
+  if l:changes > 1
+    let l:change_summary = l:change_summary . 's'
+  endif
+  let l:branch = systemlist(l:command . ' rev-parse --abbrev-ref HEAD')[0]
+  return '(' . l:branch . ')' . ' ' . l:change_summary
 endfunction
 
 function! flog#do_graph_update_hook(graph_buff_num) abort


### PR DESCRIPTION
If you have vim-airline installed and the following in vimrc:

```
let g:airline_filetype_overrides = {
      \ 'floggraph':  [ 'Flog', '%{get(b:, "flog_status_summary", "")}' ]
      \}
```

You get a status summary at the bottom of flog git log graph buffers.

![Screenshot from 2021-06-04 16-45-13](https://user-images.githubusercontent.com/5008897/120819897-4e820280-c554-11eb-963e-6c08a1bbae09.png)

If we can agree on at least the name of the buffer-local variable, then we can get the above code merged into vim-airline itself, and no longer require any user-side config for this to work. That's also why I am submitting this one before rebasing my other PR onto your master - it will save me one more plugin that I need to keep a custom fork for.

