### PR TITLE
Add up/down navigate functions

### DIFF
--- a/autoload/flog.vim
+++ b/autoload/flog.vim
@@ -84,6 +84,31 @@ endfunction
 
 " }}}
 
+" up/down navigate operations {{{
+
+" If you bind these to j and k,
+" you can more naturally go up and down one commit,
+" while still being able to use your relative
+" line numbers as expected
+function! flog#up() abort
+  if v:count1 == 1
+    call flog#previous_commit()
+  else
+    execute 'normal! ' . v:count1 . 'k'
+  endif
+endfunction
+
+function! flog#down() abort
+  if v:count1 == 1
+    call flog#next_commit()
+  else
+    execute 'normal! ' . v:count1 . 'j'
+  endif
+endfunction
+
+" }}}
+
+
 " Deprecation helpers {{{
 
 function! flog#show_deprecation_warning(deprecated_usage, new_usage) abort

--- a/doc/flog.txt
+++ b/doc/flog.txt
@@ -472,6 +472,20 @@ g:flog_use_ansi_esc                                      *g:flog_use_ansi_esc*
   For more details, help and installation, see AnsiEsc:
   <https://github.com/vim-scripts/AnsiEsc.vim>
 
+g:flog_no_jk_override                                  g:flog_no_jk_override
+
+  By default, pressing j and k inside a flog window will go up/down, but skip
+  over graph-only lines, as those aren't generally useful to navigate to. Set
+  this variable to anything disable the mapping.
+
+  For example:
+
+  let g:flog_no_jk_override=1
+  augroup flog_jk_updown
+    autocmd FileType floggraph nno <buffer> <silent> d :<C-U>call flog#down()<CR>
+    autocmd FileType floggraph nno <buffer> <silent> u :<C-U>call flog#up()<CR>
+  augroup END
+
 ==============================================================================
 FUNCTIONS                                                     *flog-functions*
 

--- a/plugin/flog.vim
+++ b/plugin/flog.vim
@@ -8,6 +8,17 @@ let g:loaded_flog = 1
 
 " }}}
 
+" Default mappings {{{
+
+if !exists("g:flog_no_jk_override")
+  augroup flog_jk_updown
+    autocmd FileType floggraph nno <buffer> <silent> j :<C-U>call flog#down()<CR>
+    autocmd FileType floggraph nno <buffer> <silent> k :<C-U>call flog#up()<CR>
+  augroup END
+endif
+
+" }}}
+
 " Global state {{{
 
 let g:flog_instance_counter = 0


### PR DESCRIPTION
goes to the next/previous commit unless a count is specified - so that
you can still use 5j to go down 5 lines, in order to not break that
usage of relative line numbers.

The least controversial subset of the rejected [quick navigation PR](https://github.com/rbong/vim-flog/pull/48).