### PR TITLE
Fix "l:opts" key not present error for :Flogsetargs command

### DIFF
--- a/autoload/flog/cmd.vim
+++ b/autoload/flog/cmd.vim
@@ -35,7 +35,7 @@ function! flog#cmd#FlogSetArgs(args, force) abort
   let l:state = flog#state#GetBufState()
 
   let l:workdir = flog#state#GetWorkdir(l:state)
-  let l:opts = a:force ? flog#state#GetInternalDefaultOpts() : l:state.l:opts
+  let l:opts = a:force ? flog#state#GetInternalDefaultOpts() : l:state.opts
 
   call flog#cmd#flog#args#Parse(l:opts, l:workdir, a:args)
   call flog#state#SetOpts(l:state, l:opts)


### PR DESCRIPTION
Before the commit, executing :Flogsetargs will show following error:
```
Error detected while processing function flog#cmd#FlogSetArgs:
line    4:
E716: Key not present in Dictionary: "l:opts"
```