### PR TITLE
Add forest-style top, bottom and middle commit symbols for v2

### DIFF
--- a/syntax/floggraph.vim
+++ b/syntax/floggraph.vim
@@ -134,7 +134,7 @@ for branch_idx in range(1, 9)
   exec 'syntax match ' . branch . ' contained nextgroup=' . next_branch . ',' . next_branch . 'Commit,' . next_branch . 'MergeStart,' . next_branch . 'ComplexMergeStart,' . next_branch . 'MissingParentsStart,flogCollapsedCommit,@flogDiff /\v%(  |%u2502 |%u2502$)/'
 
   " Commit indicators
-  exec 'syntax match ' . branch . 'Commit contained nextgroup=' . next_branch . 'AfterCommit,@flogCommitInfo /\%u2022 /'
+  exec 'syntax match ' . branch . 'Commit contained nextgroup=' . next_branch . 'AfterCommit,@flogCommitInfo /\v%(%u2022|%u250c|%u251c|%u2514) /'
   exec 'highlight link ' . branch . 'Commit flogCommit'
 
   " Branches to the right of the commit indicator
@@ -142,7 +142,7 @@ for branch_idx in range(1, 9)
   exec 'highlight link ' . branch . 'AfterCommit ' . branch
 
   " Start of a merge - saves the branch that the merge starts on (see below)
-  exec 'syntax match ' . branch . 'MergeStart contained nextgroup=' . next_merge_branch . ',' . next_merge_branch . 'End /\v%(%u251c|%u256d|%u2570)/'
+  exec 'syntax match ' . branch . 'MergeStart contained nextgroup=' . next_merge_branch . ',' . next_merge_branch . 'End /\v%(%u251c|%u256d|%u2570)[^ ]/'
   exec 'highlight link ' . branch . 'MergeStart ' . branch
 
   " Horizontal merge character


### PR DESCRIPTION
![flog_v2_forest](https://github.com/rbong/vim-flog/assets/5008897/79eab01a-9cec-431e-9875-d6c1a049365f)

As you know, I like to use ┌ ├ └ for the commits in the style of a certain git-forest fork, because it gives me lines to follow visually. With flog v1 this works:

Plug 'rbong/vim-flog', { 'branch': 'v1' }
Plug 'TamaMcGlinn/flog-forest', { 'branch': 'v1' }

Also, I really like your change where disconnected commits get a blank line. It should also allow me to paragraph-jump with <shift-]> but for some reason this does not work. I also tried and failed to find the source of the single space on that line, as I have a global setting somewhere I cannot find that visualizes that as a little grey dot.

![flog_v2_forest_disconnect](https://github.com/rbong/vim-flog/assets/5008897/1cbefa4c-ef93-4808-8a22-f678cefead97)

And if commits are disconnected on both sides, I use the circle you have currently in v2:

![flog_v2_forest_disconnected](https://github.com/rbong/vim-flog/assets/5008897/497c6254-2ae5-49da-a2a9-b6b62e92f692)

Now, performance-wise, I have added a map that has each commit in it, and looking up in that map once for every line. I think the effect is negligible, but will see if I can measure that with a few large repo's and let you know.