### PR TITLE
docs: add lazy.nvim instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,19 @@ Plug 'tpope/vim-fugitive'
 Plug 'rbong/vim-flog'
 ```
 
+For lazy.nvim users:
+
+```lua
+{
+  "rbong/vim-flog",
+  lazy = true,
+  cmd = { "Flogsplit", "Flog" },
+  dependencies = {
+    "tpope/vim-fugitive",
+  },
+},
+```
+
 ## Using Flog
 
 Basics:


### PR DESCRIPTION
[lazy.nvim](https://github.com/folke/lazy.nvim) is one of the most popular plugin managers for Neovim now.

This install snippet is working good for me.
