### PR TITLE
Use top bottom and middle commit symbols

### DIFF
--- a/syntax/floggraph.vim
+++ b/syntax/floggraph.vim
@@ -134,7 +134,7 @@ for branch_idx in range(1, 9)
   exec 'syntax match ' . branch . ' contained nextgroup=' . next_branch . ',' . next_branch . 'Commit,' . next_branch . 'MergeStart,' . next_branch . 'ComplexMergeStart,' . next_branch . 'MissingParentsStart,flogCollapsedCommit,@flogDiff /\v%(  |%u2502 |%u2502$)/'
 
   " Commit indicators
-  exec 'syntax match ' . branch . 'Commit contained nextgroup=' . next_branch . 'AfterCommit,@flogCommitInfo /\%u2022 /'
+  exec 'syntax match ' . branch . 'Commit contained nextgroup=' . next_branch . 'AfterCommit,@flogCommitInfo /\v%(%u2022|%u250c|%u251c|%u2514) /'
   exec 'highlight link ' . branch . 'Commit flogCommit'
 
   " Branches to the right of the commit indicator
@@ -142,7 +142,7 @@ for branch_idx in range(1, 9)
   exec 'highlight link ' . branch . 'AfterCommit ' . branch
 
   " Start of a merge - saves the branch that the merge starts on (see below)
-  exec 'syntax match ' . branch . 'MergeStart contained nextgroup=' . next_merge_branch . ',' . next_merge_branch . 'End /\v%(%u251c|%u256d|%u2570)/'
+  exec 'syntax match ' . branch . 'MergeStart contained nextgroup=' . next_merge_branch . ',' . next_merge_branch . 'End /\v%(%u251c|%u256d|%u2570)[^ ]/'
   exec 'highlight link ' . branch . 'MergeStart ' . branch
 
   " Horizontal merge character


### PR DESCRIPTION
I like to use ┌ ├ └ for the commits, because it gives me lines to follow visually. With flog v1 this works:

Plug 'rbong/vim-flog', { 'branch': 'v1' }
Plug 'TamaMcGlinn/flog-forest', { 'branch': 'v1' }

But with v2 the ability to customize the forest used in the background was lost, so I have re-added this by checking if the commit has child commits already drawn, and whether it has children that will later be drawn, and still falling back to the • if neither (disconnected commits).

The change to the MergeStart line just makes it a little more strict, as it must be followed by a non-space character such as ──╮. Otherwise, it thinks each middle-commit line is actually a mergestart line and those commit lines become all-white.

Here's a video of me switching between this commit and its parent. I have checked and this works without any merge conflicts on current rbong/master. I have also been using this since the commit date one year ago, across a wide variety of repos, including very large ones, with no issues whatsoever.

[flog_top_bottom_middle.webm](https://github.com/rbong/vim-flog/assets/5008897/7c54a8a3-512b-4f16-876c-e70cc90ae412)