### PR TITLE
feat: perl-regexp support

### DIFF
--- a/autoload/flog/cmd/flog/args.vim
+++ b/autoload/flog/cmd/flog/args.vim
@@ -70,6 +70,10 @@ function! flog#cmd#flog#args#Parse(current_opts, workdir, args) abort
       let a:current_opts.reverse = v:true
     elseif l:arg ==# '-no-reverse'
       let a:current_opts.reverse = v:false
+    elseif l:arg ==# '-perl-regexp'
+      let a:current_opts.perl_regexp = v:true
+    elseif l:arg ==# '-no-perl-regexp'
+      let a:current_opts.perl_regexp = v:false
     elseif l:arg ==# '-graph'
       let a:current_opts.graph = v:true
     elseif l:arg ==# '-no-graph'
@@ -328,6 +332,8 @@ function! flog#cmd#flog#args#Complete(arg_lead, cmd_line, cursor_pos) abort
         \ '-rev=',
         \ '-reverse ',
         \ '-no-reverse ',
+        \ '-perl-regexp ',
+        \ '-no-perl-regexp ',
         \ '-search=',
         \ '-grep=',
         \ '-skip=',

--- a/autoload/flog/floggraph/git.vim
+++ b/autoload/flog/floggraph/git.vim
@@ -88,6 +88,9 @@ function! flog#floggraph#git#BuildLogArgs() abort
   if l:opts.reflog
     let l:args .= ' --reflog'
   endif
+  if l:opts.perl_regexp
+    let l:args .= ' --perl-regexp'
+  endif
   if l:opts.reverse
     let l:args .= ' --reverse'
   endif

--- a/autoload/flog/state.vim
+++ b/autoload/flog/state.vim
@@ -48,6 +48,7 @@ function! flog#state#GetInternalDefaultOpts() abort
         \ 'reflog': v:false,
         \ 'related': v:false,
         \ 'reverse': v:false,
+        \ 'perl_regexp': v:false,
         \ 'graph': v:true,
         \ 'patch': -1,
         \ 'skip': '',

--- a/doc/flog.txt
+++ b/doc/flog.txt
@@ -125,6 +125,13 @@ Quotes are not supported for completion reasons.
   Requires |:Flog_-no-graph|.
   Disabled by default.
 
+:Flog -perl-regexp                                        *:Flog_-perl-regexp*
+:Flog -no-perl-regexp                                  *:Flog_-no-perl-regexp*
+
+  When enabled, pass the "--perl-regexp" argument to "git log".
+  This makes patterns such as |:Flog_-search| use Perl-compatible regexps.
+  Disabled by default.
+
 :Flog -patch                                                    *:Flog_-patch*
 :Flog -no-patch                                              *:Flog_-no-patch*
 


### PR DESCRIPTION
Adds a `:Flog -perl-regexp` flag.

This was vibe-coded, but this seems to be consistent with flag handling + works on my machine™️.

Closes #162.