### PR TITLE
fix: related with detached HEAD

### DIFF
--- a/autoload/flog/git.vim
+++ b/autoload/flog/git.vim
@@ -148,8 +148,14 @@ function! flog#git#SplitRemote(ref, remotes) abort
 endfunction
 
 function! flog#git#GetHeadRef() abort
-  let l:cmd = flog#git#GetCommand(['symbolic-ref', '--short', 'HEAD'])
-  return flog#shell#Run(l:cmd)[0]
+  " Use --quiet and a non-throwing run: a detached HEAD makes symbolic-ref
+  " exit non-zero, which should yield an empty ref rather than an error.
+  let l:cmd = flog#git#GetCommand(['symbolic-ref', '--quiet', '--short', 'HEAD'])
+  let l:output = flog#shell#Systemlist(l:cmd)
+  if !empty(v:shell_error) || empty(l:output)
+    return ''
+  endif
+  return l:output[0]
 endfunction
 
 function! flog#git#GetRelatedRefs(revs = []) abort


### PR DESCRIPTION
`:Flog -related` would error when checking out a detached `HEAD`.

Now, we circumvent the error `git symbolic-ref --short HEAD` gives in `GetHeadRef` and output an empty ref list instead.

The use case is e.g. rebasing with `:Flog -related -update` open, which would make the flog buffer crash and burn.

Vibe-coded again, works on my system™️